### PR TITLE
Do not raise on final job retry failure

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,7 +6,9 @@ class ApplicationJob < ActiveJob::Base
   retry_on ActiveRecord::Deadlocked
 
   # Retry on HTTP errors
-  retry_on HTTPX::HTTPError, wait: HTTP_5XX_RETRY_DELAY
+  retry_on(HTTPX::HTTPError, wait: HTTP_5XX_RETRY_DELAY) do |job, error|
+    # Do not raise the error on the final retry
+  end
 
   # We ignore invalid JSON (which is often just HTML from error pages and/or misconfigured web servers
   discard_on JSON::ParserError

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,7 +6,9 @@ class ApplicationJob < ActiveJob::Base
   retry_on ActiveRecord::Deadlocked
 
   # Retry on HTTP errors
-  retry_on HTTPX::HTTPError, wait: HTTP_5XX_RETRY_DELAY
+  retry_on(HTTPX::HTTPError, wait: HTTP_5XX_RETRY_DELAY) do |job, error|
+    # Do not raise the error on the final retry
+  end
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   discard_on ActiveJob::DeserializationError

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,13 +1,26 @@
 class ApplicationJob < ActiveJob::Base
   # Spread out retries caused by HTTP 5xx errors
-  HTTP_5XX_RETRY_DELAY = ->(executions) { executions ** 5 + 30 }
+  HTTP_RETRY_DELAY = ->(executions) { executions ** 5 + 30 }
 
   # Automatically retry jobs that encountered a deadlock
   retry_on ActiveRecord::Deadlocked
 
-  # Retry on HTTP errors
-  retry_on(HTTPX::HTTPError, wait: HTTP_5XX_RETRY_DELAY) do |job, error|
-    # Do not raise the error on the final retry
+  # Retry on HTTP 4xx/5xx errors
+  # Only allows 4xx errors to bubble up as these could hint at
+  # fediscoverer doing something wrong. 5xx errors mean that
+  # something is wrong on the other end, so once all the retries
+  # are exhausted, there is no need to raise the exception any
+  # more.
+  retry_on(HTTPX::HTTPError, wait: HTTP_RETRY_DELAY) do |_job, error|
+    raise error if error.status < 500
+  end
+
+  # Handle other types of connection errors
+  # Again, we cannot do anything about this other than retrying,
+  # so once all retry attempts have been exhausted, we do not
+  # want the exception to be raised further.
+  retry_on(HTTPX::TimeoutError, HTTPX::Connection::HTTP2::Error, wait: HTTP_RETRY_DELAY) do |_job, _error|
+    # Do nothing
   end
 
   # We ignore invalid JSON (which is often just HTML from error pages and/or misconfigured web servers


### PR DESCRIPTION
This way, a job that failed 5 times because of HTTP 5XX errors should not appear as failed job in SolidQueue.