### PR TITLE
Optional JSON logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ fediscoverer can be configured using environment variables. Here is a
 | `DATABASE_URL` | No |  | Optional PostgreSQL URL to set database host, port etc. |
 | `WEB_CONCURRENCY` | No | `1` | Number of puma application server processes. Can be set to the number of CPUs to make use of all of them |
 | `JOB_CONCURRENCY` | No | `1` | Number of Solid Queue processes. Can be set to the number of CPUs to make use of all of them |
+| `JSON_LOGGING` | No | false | Enable log output to be in JSON format |
 | `PROMETHEUS_EXPORTER_ENABLED` | No | false | Enable metrics gathering |
 | `PROMETHEUS_EXPORTER_HOST` | No | `localhost` | Host where the `prometheus_exporter` service is running |
 | `PROMETHEUS_EXPORTER_PORT` | No | `9394` | Port that the `prometheus_exporter` service is listening on |

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require "json_logging"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -30,9 +31,14 @@ Rails.application.configure do
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
-  # Log to STDOUT with the current request id as a default log tag.
-  config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  if ENV.fetch('JSON_LOGGING', false) == "true"
+    config.logger   = JsonLogging::Logger.new(STDOUT, name: "fediscoverer-web")
+    config.solid_queue.logger = JsonLogging::Logger.new(STDOUT, name: "fediscoverer-jobs")
+  else
+    # Log to STDOUT with the current request id as a default log tag.
+    config.log_tags = [ :request_id ]
+    config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  end
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")

--- a/lib/json_logging.rb
+++ b/lib/json_logging.rb
@@ -1,0 +1,3 @@
+require_relative "./json_logging/action_controller_log_subscriber"
+require_relative "./json_logging/formatter"
+require_relative "./json_logging/logger"

--- a/lib/json_logging/action_controller_log_subscriber.rb
+++ b/lib/json_logging/action_controller_log_subscriber.rb
@@ -1,0 +1,31 @@
+module JsonLogging
+  class ActionControllerLogSubscriber < ActiveSupport::LogSubscriber
+    def process_action(event)
+      # return if event.payload[:exception].present?
+
+      request = event.payload[:request]
+      response = event.payload[:response]
+      error = event.payload[:exception]
+
+      params = request.filtered_parameters
+
+      info do
+        req = {
+          id: request.request_id,
+          method: request.request_method,
+          url: request.filtered_path,
+          remoteAddress: request.remote_ip
+        }
+        req[:params] = params if params.present?
+
+        {
+          req:,
+          res: {
+            statusCode: error ? 500 : response.status
+          },
+          responseTime: event.duration.to_i
+        }
+      end
+    end
+  end
+end

--- a/lib/json_logging/formatter.rb
+++ b/lib/json_logging/formatter.rb
@@ -1,0 +1,29 @@
+module JsonLogging
+  class Formatter
+    def initialize(name)
+      @name = name
+      @hostname = Socket.gethostname
+    end
+
+    def call(severity, time, _progname, payload)
+      pid = Process.pid
+
+      log = {
+        level: severity.downcase,
+        time: time.to_i,
+        pid:,
+        hostname: @hostname,
+        name: @name,
+      }
+
+      case payload
+      when Hash
+        log.merge!(payload)
+      else
+        log.merge!(msg: payload)
+      end
+
+      log.to_json + "\n"
+    end
+  end
+end

--- a/lib/json_logging/logger.rb
+++ b/lib/json_logging/logger.rb
@@ -1,0 +1,30 @@
+module JsonLogging
+  class Logger < ::ActiveSupport::Logger
+    class_attribute :json_logging_initialized
+
+    def self.initialize_json_logging
+      # Suppress some built-in, per-request logging
+      ::ActiveSupport.on_load(:action_controller) do
+        ::ActionController::LogSubscriber.detach_from :action_controller
+      end
+      ::ActiveSupport.on_load(:action_view) do
+        ::ActionView::LogSubscriber.detach_from :action_view
+      end
+
+      # Install JSON-aware request log subscriber
+      ActionControllerLogSubscriber.attach_to :action_controller
+
+      json_logging_initialized = true
+    end
+
+    def initialize(logdev = STDOUT, name: "rails")
+      self.class.initialize_json_logging unless json_logging_initialized?
+      @formatter = Formatter.new(name)
+      super(logdev)
+    end
+
+    def formatter=(_)
+      # We do not allow using a different formatter here
+    end
+  end
+end


### PR DESCRIPTION
Fixes MAS-479

Optionally changes rails' and SolidQueue's logger in `production` to a custom one that emits JSON objects.

The format is modeled after pino (or rather [pino-http](https://github.com/pinojs/pino-http)) as we contemplate adding this to Mastodon as well. And we already use pino for the streaming server there.