### PR TITLE
Small Json logging fixes

### DIFF
--- a/lib/json_logging/formatter.rb
+++ b/lib/json_logging/formatter.rb
@@ -20,10 +20,10 @@ module JsonLogging
       when Hash
         log.merge!(payload)
       else
-        log.merge!(msg: payload)
+        log.merge!(msg: payload.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace))
       end
 
-      log.to_json + "\n"
+      "#{log.to_json}\n"
     end
   end
 end

--- a/lib/json_logging/logger.rb
+++ b/lib/json_logging/logger.rb
@@ -14,7 +14,7 @@ module JsonLogging
       # Install JSON-aware request log subscriber
       ActionControllerLogSubscriber.attach_to :action_controller
 
-      json_logging_initialized = true
+      self.json_logging_initialized = true
     end
 
     def initialize(logdev = STDOUT, name: "rails")


### PR DESCRIPTION
Remove double initialization and make more robust when faced with broken encoding (e.g. of URL parameters).