### PR TITLE
Solid queue connection pool size configuration

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -93,4 +93,4 @@ production:
     <<: *primary_production
     database: fediscoverer_production_queue
     migrations_paths: db/queue_migrate
-    pool: <%= 2 * ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+    pool: <%= ENV.fetch("QUEUE_CONNECTION_POOL_SIZE", ENV.fetch("RAILS_MAX_THREADS", 5)) %>


### PR DESCRIPTION
We are experiencing problems with the connection pool. This makes this value configurable via env variable so it is easier to experiment with different values. Should be backwards compatible, so no changes are needed for existing deployments.