### PR TITLE
Fix query to handle large numbers

### DIFF
--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -25,7 +25,7 @@ class Actor < ApplicationRecord
 
   scope :discoverable, -> { where(discoverable: true) }
   scope :most_popular, -> {
-    select("actors.*, (2 * actors.followers_count + SUM(content_objects.likes) + SUM(content_objects.shares)) AS popularity")
+    select("actors.*, (2::bigint * actors.followers_count + SUM(content_objects.likes) + SUM(content_objects.shares)) AS popularity")
       .joins(:content_objects)
       .discoverable
       .group("actors.id")

--- a/test/fixtures/actors.yml
+++ b/test/fixtures/actors.yml
@@ -59,6 +59,15 @@ blocked:
   full_text: please find me
   blocked: true
 
+popular:
+  server: mastodon
+  uri: https://mastodon.example.com/users/72
+  actor_type: Person
+  discoverable: true
+  indexable: true
+  full_text: Very popular
+  followers_count: 2147483647
+
 <% 20.times do |i| %>
 discoverable<%= i %>:
   server: mastodon

--- a/test/fixtures/content_objects.yml
+++ b/test/fixtures/content_objects.yml
@@ -48,6 +48,22 @@ complex_language_tag:
   likes: 1
   shares: 1
 
+popular:
+  actor: popular
+  uri: https://mastodon.example.com/posts/77
+  object_type: Note
+  full_text: MyString
+  published_at: 2025-01-17 11:59:13
+  last_edited_at: 2025-01-17 11:59:13
+  sensitive: false
+  language: en
+  attached_images: 0
+  attached_videos: 0
+  attached_audio: 0
+  replies: 1
+  likes: 2000000
+  shares: 1000000
+
 <% 40.times do |i| %>
 note<%= i %>:
   actor: discoverable<%= i / 2 %>

--- a/test/models/actor_test.rb
+++ b/test/models/actor_test.rb
@@ -26,4 +26,10 @@ class ActorTest < ActiveSupport::TestCase
     discoverable = actors(:discoverable)
     assert discoverable.content_indexable?
   end
+
+  test "::most_popular handles large numbers" do
+    most_popular = Actor.most_popular
+
+    assert_equal actors(:popular), most_popular.first
+  end
 end


### PR DESCRIPTION
We finally have so much data, that the follow recommendation endpoint errors out, because the calculation goes over the bounds of a simple integer.

This fixes that situation by casting the static factor to `bigint`, making sure subsequent results are also of type `bigint`.