### PR TITLE
Quick fix for multiple actors in `attributedTo`

### DIFF
--- a/app/models/content_object.rb
+++ b/app/models/content_object.rb
@@ -62,8 +62,11 @@ class ContentObject < ApplicationRecord
 
       # Retrieve actor if unknown, skip if missing
       return unless json_object["attributedTo"].present?
-      RetrieveActorJob.perform_now(json_object["attributedTo"])
-      actor = Actor.where(uri: json_object["attributedTo"]).take
+      actor_uri = json_object["attributedTo"]
+      actor_uri = actor_uri.first if actor_uri.is_a?(Array)
+      actor_uri = actor_uri["id"] if actor_uri.is_a?(Hash)
+      RetrieveActorJob.perform_now(actor_uri)
+      actor = Actor.where(uri: actor_uri).take
 
       # Stop if author not retrievable or has not opted-in to indexing
       # or is blocked altogether

--- a/test/models/content_object_test.rb
+++ b/test/models/content_object_test.rb
@@ -130,6 +130,26 @@ class ContentObjectTest < ActiveSupport::TestCase
     end
   end
 
+  test "::create_from_json! picks the first actor if `attributedTo` is an array" do
+    known_actor = actors(:discoverable)
+    unknown_actor_uri = "https://unknown.example.com/users/NewActor"
+
+    # Case one: URIs in an array
+    object = mock_content_object(actor: [ known_actor.uri, unknown_actor_uri ])
+
+    content_object = ContentObject.create_from_json!(object)
+    assert_equal known_actor, content_object.actor
+
+    # Case two: Objects in an array
+    object = mock_content_object(actor: [
+      { id: known_actor.uri },
+      { id: unknown_actor_uri }
+    ])
+
+    content_object = ContentObject.create_from_json!(object)
+    assert_equal known_actor, content_object.actor
+  end
+
   test "::trending returns the given number of records" do
     trending = ContentObject.trending(limit: 11)
 


### PR DESCRIPTION
This picks the first one, just like Mastodon would do.

It just intended as a band-aid to reduce log noise. WEB-1092 should provide a better long-term solution.