### PR TITLE
Replace tailwindcss with static CSS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,6 @@ gem "importmap-rails"
 gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
-# Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
-gem "tailwindcss-rails", "< 5"
-gem "tailwindcss-ruby", "4.3.0" # 4.3.1 currently errors out
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,16 +360,6 @@ GEM
       base64
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
-    tailwindcss-rails (4.6.0)
-      railties (>= 7.0.0)
-      tailwindcss-ruby (~> 4.0)
-    tailwindcss-ruby (4.3.0)
-    tailwindcss-ruby (4.3.0-aarch64-linux-gnu)
-    tailwindcss-ruby (4.3.0-aarch64-linux-musl)
-    tailwindcss-ruby (4.3.0-arm64-darwin)
-    tailwindcss-ruby (4.3.0-x86_64-darwin)
-    tailwindcss-ruby (4.3.0-x86_64-linux-gnu)
-    tailwindcss-ruby (4.3.0-x86_64-linux-musl)
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -436,8 +426,6 @@ DEPENDENCIES
   solid_cache
   solid_queue
   stimulus-rails
-  tailwindcss-rails (< 5)
-  tailwindcss-ruby (= 4.3.0)
   turbo-rails
   tzinfo-data
   web-console

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,1 @@
 web: bin/rails server
-css: bin/rails tailwindcss:watch

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,3 +8,303 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+
+/* Variables */
+
+:root {
+  --background-color: rgb(223, 216, 213);
+  --soft-background-color: rgb(242, 239, 238);
+  --container-background-color: white;
+  --border-color: rgb(223, 216, 213);
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --text-color: rgb(71, 82, 97);
+  --info-color: rgb(114, 187, 227);
+  --success-color: rgb(122, 194, 143);
+  --warn-color: rgb(203, 98, 121);
+
+  @media (prefers-color-scheme: dark) {
+    --background-color: rgb(15, 13, 12);
+    --soft-background-color: rgb(119, 111, 105);
+    --container-background-color: rgb(37, 33, 32);
+    --shadow-color: rgba(223, 216, 213, 0.3);
+    --text-color: rgb(229, 228, 227);
+  }
+}
+
+
+/* Reset */
+*, *::before, *::after {
+  box-sizing: border-box;
+  border: 0 solid;
+  margin: 0;
+  padding: 0;
+}
+
+/* Base styles */
+
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+
+  font-family: sans;
+  line-height: 1.5;
+}
+
+header {
+  background-color: var(--container-background-color);
+  box-shadow: 0 1px 3px 0 var(--shadow-color);
+  margin-bottom: 2rem;
+
+  nav {
+    display: flex;
+    justify-content: space-between;
+    padding: 1rem;
+
+    section {
+      display: flex;
+      gap: 2rem;
+
+      a {
+        text-decoration: none;
+        color: var(--text-color);
+        padding-block: 0.25rem;
+        padding-inline: 0.5rem;
+        border-radius: 0.25rem;
+
+        &:visited {
+          color: var(--text-color);
+        }
+
+        &:hover {
+          background-color: var(--background-color);
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+}
+
+main {
+  background-color: var(--container-background-color);
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 3px 0 var(--shadow-color);
+  padding-block: 0.5rem;
+  padding-inline: 1.25rem;
+
+  h1, h2, h3 {
+    margin-bottom: 1rem;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+
+    input[type="text"], input[type="url"], input[type="email"], input[type="password"], input[type="number"], textarea {
+      padding-block: 0.25rem;
+      padding-inline: 0.5rem;
+      font-size: 1rem;
+      line-height: 1.5;
+      border: 1px solid var(--text-color);
+    }
+
+    input[type="button"], button {
+      padding-block: 0.5rem;
+      padding-inline: 1rem;
+      margin-block: 1rem;
+      border: 1px solid var(--text-color);
+      border-radius: 0.25rem;
+      box-shadow: 0 1px 3px 0 var(--shadow-color);
+      font-size: 1rem;
+      background-color: var(--container-background-color);
+      color: var(--text-color);
+
+      &:hover {
+        background-color: var(--background-color);
+      }
+    }
+  }
+
+  nav[role=tablist] {
+    display: flex;
+    gap: 0.5rem;
+    margin-block: 1rem;
+    border-bottom: 1px solid var(--border-color);
+
+    a {
+      text-decoration: none;
+      padding-block: 0.5rem;
+      padding-inline: 1rem;
+      color: var(--text-color);
+
+      &:visited {
+        color: var(--text-color);
+      }
+
+      &:hover {
+        background-color: var(--background-color);
+      }
+
+      &[aria-selected=true] {
+        border: 1px solid var(--border-color);
+        border-bottom: none;
+      }
+    }
+  }
+
+  table {
+    tbody {
+      tr {
+        &:hover, &:nth-child(even):hover {
+          background-color: var(--background-color);
+        }
+
+        &:nth-child(even) {
+          background-color: var(--soft-background-color);
+        }
+
+        th {
+          text-align: left;
+        }
+
+        td {
+          padding-block: 0.75rem;
+          padding-inline: 0.5rem;
+        }
+      }
+    }
+  }
+
+  ul, ol {
+    list-style-position: inside;
+
+    li {
+      margin-bottom: 0.25rem;
+
+      &:nth-child(even) {
+        background-color: var(--soft-background-color);
+      }
+    }
+  }
+}
+
+/* Components */
+
+section.page-header {
+  display: flex;
+  justify-content: space-between;
+
+  form {
+    button {
+      margin-block: 0;
+    }
+  }
+}
+
+section.alert {
+  border-width: 2px;
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 3px 0 var(--shadow-color);
+  padding-block: 0.5rem;
+  padding-inline: 1rem;
+  margin-bottom: 1rem;
+  font-weight: bold;
+
+  &.alert-alert {
+    border-color: var(--warn-color);
+  }
+
+  &.alert-notice {
+    border-color: var(--info-color);
+  }
+}
+
+section.columns {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-bottom: 2rem;
+
+  @media (min-width: 48rem) {
+    flex-direction: row;
+
+    & > * {
+      flex-grow: 1;
+    }
+  }
+}
+
+div.infobox {
+  border: 1px solid var(--border-color);
+  padding: 1rem;
+  box-shadow: 0 1px 3px 0 var(--shadow-color);
+
+  table {
+    width: 100%;
+  }
+}
+
+div.button-group {
+  display: flex;
+  width: fit-content;
+  gap: 0;
+  margin-block: 1rem;
+  border: 1px solid var(--text-color);
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 3px 0 var(--shadow-color);
+  background-color: var(--container-background-color);
+
+  .button-group-selected {
+    padding: 1rem;
+    background-color: var(--background-color);
+    font-size: 1rem;
+    font-weight: bold;
+  }
+
+  form {
+    display: inline;
+
+    button {
+      line-height: 1.5;
+      padding: 1rem;
+      margin: 0;
+      box-shadow: none;
+      border: none;
+      border-radius: 0;
+    }
+  }
+}
+
+/* Utilities */
+
+.container {
+  width: 100%;
+  margin-inline: auto;
+
+  @media (min-width: 40rem) {
+    max-width: 40rem;
+  }
+
+  @media (min-width: 48rem) {
+    max-width: 48rem;
+  }
+
+  @media (min-width: 64rem) {
+    max-width: 64rem;
+  }
+
+  @media (min-width: 80rem) {
+    max-width: 80rem;
+  }
+
+  @media (min-width: 96rem) {
+    max-width: 96rem;
+  }
+}
+
+.flex {
+  display: flex;
+}
+
+.flex-col {
+  flex-direction: column;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,19 @@
 module ApplicationHelper
-  include FaspBase::ApplicationHelper
-
   TRENDS_TABS = {
     content: :content_trends_path,
     hashtags: :hashtag_trends_path,
     links: :link_trends_path
   }.freeze
+
+  def render_notification(message, type: :notice)
+    tag.section(message, class: "alert alert-#{type}")
+  end
+
+  def render_tabs(tabs, active:, scope:)
+    rendered_tabs = tabs.map do |key, path|
+      text = t(key, scope:)
+      link_to text, send(path), aria: { selected: (key == active) }
+    end
+    tag.nav safe_join(rendered_tabs), role: "tablist"
+  end
 end

--- a/app/views/account_searches/show.html.erb
+++ b/app/views/account_searches/show.html.erb
@@ -1,35 +1,33 @@
-<%= page_header do %>
-  <%= t(".account_search") %>
-<% end %>
+<h1><%= t(".account_search") %></h1>
 
-<div class="my-4">
+<section>
   <%= form_with method: :get do |f| %>
-    <div class="flex gap-2">
+    <div>
       <%= f.text_field :term, value: params[:term], size: 50 %>
-      <%= button type: :submit do %>
-        <%= t(".search") %>
-      <% end %>
+      <button type="submit"><%= t(".search") %></button>
     </div>
   <% end %>
-</div>
+</section>
 
-<% if @actors.any? %>
-  <table>
-    <thead>
-      <tr>
-        <th><%= Actor.human_attribute_name(:uri) %></th>
-        <th><%= Actor.human_attribute_name(:actor_type) %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @actors.each do |actor| %>
+<section>
+  <% if @actors.any? %>
+    <table>
+      <thead>
         <tr>
-          <%= td do %>
-            <%= link_to truncate(actor.uri, length: 100), actor.uri %>
-          <% end %>
-          <%= td do %><%= actor.actor_type %><% end %>
+          <th><%= Actor.human_attribute_name(:uri) %></th>
+          <th><%= Actor.human_attribute_name(:actor_type) %></th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% end %>
+      </thead>
+      <tbody>
+        <% @actors.each do |actor| %>
+          <tr>
+            <td>
+              <%= link_to truncate(actor.uri, length: 100), actor.uri %>
+            </td>
+            <td><%= actor.actor_type %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</section>

--- a/app/views/admin/follow_recommendation_presets/index.html.erb
+++ b/app/views/admin/follow_recommendation_presets/index.html.erb
@@ -1,17 +1,11 @@
-<div class="flex justify-between items-center">
-  <%= page_header do %>
-    <%= t(".follow_recommendation_presets") %>
-  <% end %>
-</div>
+<h1><%= t(".follow_recommendation_presets") %></h1>
 
-<p class="font-lg text-gray-700"><%= t(".follow_recommendation_presets_description") %></p>
+<p><%= t(".follow_recommendation_presets_description") %></p>
 
 <%= form_with url: admin_follow_recommendation_presets_path do |f| %>
-  <div class="flex gap-2">
+  <div>
     <%= f.url_field :uri, placeholder: t(".uri_placeholder") %>
-    <%= button type: :submit do %>
-      <%= t(".add_account") %>
-    <% end %>
+    <button type="submit"><%= t(".add_account") %></button>
   </div>
 <% end %>
 
@@ -26,11 +20,11 @@
   <tbody>
     <% @follow_recommendation_presets.each do |actor| %>
       <tr class="even:bg-blue-50">
-        <%= td do %><%= actor.uri %><% end %>
-        <%= td do %><% if actor.discoverable? %>&check;<% end %><% end %>
-        <%= td do %>
+        <td><%= actor.uri %></td>
+        <td><% if actor.discoverable? %>&check;<% end %></td>
+        <td>
           <%= action_link_to t(".delete"), admin_follow_recommendation_preset_path(actor), data: {turbo_method: :delete} %>
-        <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/content_trends/index.html.erb
+++ b/app/views/content_trends/index.html.erb
@@ -1,9 +1,6 @@
 <%= render_tabs ApplicationHelper::TRENDS_TABS, active: :content, scope: "trends.tabs" %>
 
-<%= page_header do %>
-  <%= t(".content_trends") %>
-<% end %>
-
+<h1><%= t(".content_trends") %></h1>
 
 <table>
   <thead>
@@ -16,11 +13,11 @@
   <tbody>
     <% @trending_content.each do |content_object| %>
       <tr>
-        <%= td do %>
+        <td>
           <%= link_to truncate(content_object.uri, length: 100), content_object.uri %>
-        <% end %>
-        <%= td do %><%= content_object.score %><% end %>
-        <%= td do %><%= content_object.rank %><% end %>
+        </td>
+        <td><%= content_object.score %></td>
+        <td><%= content_object.rank %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,43 +1,41 @@
-<%= page_header do %>
-  <%= t(".dashboard") %>
-<% end %>
+<h1><%= t(".dashboard") %></h1>
 
-<div class="grid grid-cols-2 gap-8 mb-8">
+<section class="columns">
   <div>
-    <p class="my-4">
+    <p>
       <%= link_to t(".trends"), main_app.content_trends_path, class: "text-xl underline text-blue-400 hover:text-blue-600" %>
       <br>
       <%= t(".trends_hint") %>
     </p>
 
-    <p class="my-4">
+    <p>
       <%= link_to t(".account_search"), main_app.account_search_path, class: "text-xl underline text-blue-400 hover:text-blue-600" %>
       <br>
       <%= t(".account_search_hint") %>
     </p>
   </div>
 
-  <div class="border border-gray-100 shadow p-4">
-    <table class="w-full">
+  <div class="infobox">
+    <table>
       <tbody>
-        <tr class="hover:bg-blue-100">
-          <th class="text-left"><%= t(".indexed_accounts") %></th>
+        <tr>
+          <th><%= t(".indexed_accounts") %></th>
           <td><%= Actor.count %> (<%= Actor.discoverable.count %>)</td>
         </tr>
-        <tr class="bg-stone-100 hover:bg-blue-100">
-          <th class="text-left"><%= t(".indexed_content_objects") %></th>
+        <tr>
+          <th><%= t(".indexed_content_objects") %></th>
           <td><%= ContentObject.count %></td>
         </tr>
-        <tr class="hover:bg-blue-100">
-          <th class="text-left"><%= t(".known_hashtags") %></th>
+        <tr>
+          <th><%= t(".known_hashtags") %></th>
           <td><%= Hashtag.count %></td>
         </tr>
-        <tr class="bg-stone-100 hover:bg-blue-100">
-          <th class="text-left"><%= t(".known_links") %></th>
+        <tr>
+          <th><%= t(".known_links") %></th>
           <td><%= Link.count %></td>
         </tr>
-        <tr class="hover:bg-blue-100">
-          <th class="text-left"><%= t(".available_trends_data") %></th>
+        <tr>
+          <th><%= t(".available_trends_data") %></th>
           <td>
             <% if ContentActivity.any? %>
               <%= time_ago_in_words(ContentActivity.minimum(:hour_of_activity)) %>
@@ -49,39 +47,39 @@
       </tbody>
     </table>
   </div>
-</div>
+</section>
 
-<div class="grid grid-cols-3 gap-8">
-  <div class="border border-gray-100 shadow p-4">
-    <h3 class="font-bold mb-4"><%= t(".trending_hashtags") %></h3>
-    <ol class="list-decimal list-inside">
+<section class="columns">
+  <div class="infobox">
+    <h3><%= t(".trending_hashtags") %></h3>
+    <ol>
       <% Hashtag.trending(limit: 5).each do |hashtag| %>
-        <li class="my-2 even:bg-stone-100">
-          <span class="text-blue-400">#</span><%= hashtag.name %>
+        <li>
+          <span>#</span><%= hashtag.name %>
         </li>
       <% end %>
     </ol>
   </div>
 
-  <div class="border border-gray-100 shadow p-4">
-    <h3 class="font-bold mb-4"><%= t(".trending_links") %></h3>
-    <ol class="list-decimal list-inside">
+  <div class="infobox">
+    <h3><%= t(".trending_links") %></h3>
+    <ol>
       <% Link.trending(limit: 5).each do |link| %>
-        <li class="my-2 even:bg-stone-100">
+        <li>
           <%= link_to truncate(link.url), link.url, target: "_blank", class: "underline text-blue-400 hover:text-blue-600" %>
         </li>
       <% end %>
     </ol>
   </div>
 
-  <div class="border border-gray-100 shadow p-4">
-    <h3 class="font-bold mb-4"><%= t(".trending_content") %></h3>
-    <ol class="list-decimal list-inside">
+  <div class="infobox">
+    <h3><%= t(".trending_content") %></h3>
+    <ol>
       <% ContentObject.trending(limit: 5).each do |content_object| %>
-        <li class="my-2 even:bg-stone-100">
+        <li>
           <%= link_to truncate(content_object.uri), content_object.uri, target: "_blank", class: "underline text-blue-400 hover:text-blue-600" %>
         </li>
       <% end %>
     </ol>
   </div>
-</div>
+</section>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -3,13 +3,13 @@
 <section class="columns">
   <div>
     <p>
-      <%= link_to t(".trends"), main_app.content_trends_path, class: "text-xl underline text-blue-400 hover:text-blue-600" %>
+      <%= link_to t(".trends"), main_app.content_trends_path %>
       <br>
       <%= t(".trends_hint") %>
     </p>
 
     <p>
-      <%= link_to t(".account_search"), main_app.account_search_path, class: "text-xl underline text-blue-400 hover:text-blue-600" %>
+      <%= link_to t(".account_search"), main_app.account_search_path %>
       <br>
       <%= t(".account_search_hint") %>
     </p>
@@ -66,7 +66,7 @@
     <ol>
       <% Link.trending(limit: 5).each do |link| %>
         <li>
-          <%= link_to truncate(link.url), link.url, target: "_blank", class: "underline text-blue-400 hover:text-blue-600" %>
+          <%= link_to truncate(link.url), link.url, target: "_blank" %>
         </li>
       <% end %>
     </ol>
@@ -77,7 +77,7 @@
     <ol>
       <% ContentObject.trending(limit: 5).each do |content_object| %>
         <li>
-          <%= link_to truncate(content_object.uri), content_object.uri, target: "_blank", class: "underline text-blue-400 hover:text-blue-600" %>
+          <%= link_to truncate(content_object.uri), content_object.uri, target: "_blank" %>
         </li>
       <% end %>
     </ol>

--- a/app/views/fasp_base/admin/invitation_codes/index.html.erb
+++ b/app/views/fasp_base/admin/invitation_codes/index.html.erb
@@ -14,12 +14,12 @@
   </thead>
   <tbody>
     <% @invitation_codes.each do |invitation_code| %>
-      <tr class="even:bg-blue-50">
-        <%= td do %><%= invitation_code.code %><% end %>
-        <%= td do %><%= invitation_code.created_at %><% end %>
-        <%= td do %>
+      <tr>
+        <td><%= invitation_code.code %></td>
+        <td><%= invitation_code.created_at %></td>
+        <td>
           <%= action_link_to t(".delete"), fasp_base.admin_invitation_code_path(invitation_code), data: {turbo_method: :delete} %>
-        <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/fasp_base/admin/invitation_codes/index.html.erb
+++ b/app/views/fasp_base/admin/invitation_codes/index.html.erb
@@ -1,0 +1,26 @@
+<section class="page-header">
+  <h1><%= t(".invitation_codes") %></h1>
+
+  <%= button_to t(".add"), fasp_base.admin_invitation_codes_path, data: {turbo_method: :post} %>
+</section>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= FaspBase::InvitationCode.human_attribute_name(:code) %></th>
+      <th><%= FaspBase::InvitationCode.human_attribute_name(:created_at) %></th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @invitation_codes.each do |invitation_code| %>
+      <tr class="even:bg-blue-50">
+        <%= td do %><%= invitation_code.code %><% end %>
+        <%= td do %><%= invitation_code.created_at %><% end %>
+        <%= td do %>
+          <%= action_link_to t(".delete"), fasp_base.admin_invitation_code_path(invitation_code), data: {turbo_method: :delete} %>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/fasp_base/admin/settings/index.html.erb
+++ b/app/views/fasp_base/admin/settings/index.html.erb
@@ -1,0 +1,25 @@
+<%= page_header do %>
+  <%= t(".settings") %>
+<% end %>
+
+<div>
+  <h2 class="text-lg font-bold"><%= t(".registration") %></h2>
+  <p><%= t(".registration_hint") %></p>
+
+  <div class="button-group">
+    <% FaspBase::Setting::OPTIONS[:registration].each do |option| %>
+      <% if @registration.value == option %>
+        <div class="button-group-selected">
+          <%= t(option, scope: ".registration") %>
+        </div>
+      <% else %>
+        <%= form_with model: [:admin, @registration] do |f| %>
+          <%= f.hidden_field :value, value: option %>
+          <%= f.button type: :submit do %>
+            <%= t(option, scope: ".registration") %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/hashtag_trends/index.html.erb
+++ b/app/views/hashtag_trends/index.html.erb
@@ -1,8 +1,6 @@
 <%= render_tabs ApplicationHelper::TRENDS_TABS, active: :hashtags, scope: "trends.tabs" %>
 
-<%= page_header do %>
-  <%= t(".hashtag_trends") %>
-<% end %>
+<h1><%= t(".hashtag_trends") %></h1>
 
 
 <table>
@@ -16,9 +14,9 @@
   <tbody>
     <% @trending_hashtags.each do |hashtag| %>
       <tr>
-        <%= td do %><%= hashtag.name %><% end %>
-        <%= td do %><%= hashtag.score %><% end %>
-        <%= td do %><%= hashtag.rank %><% end %>
+        <td><%= hashtag.name %></td>
+        <td><%= hashtag.score %></td>
+        <td><%= hashtag.rank %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -13,38 +13,39 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <header class="bg-blue-100">
-      <nav class="container mx-auto p-4 flex justify-between">
-        <div class="flex gap-8">
-          <p class="font-bold text-gray-600 px-2 py-1">
+    <header>
+      <nav class="container">
+        <section>
+          <p>
             <%= Rails.application.name %>
           </p>
+        </section>
+        <section>
           <% if admin_signed_in? %>
-            <%= nav_link_to t(".users"), fasp_base.admin_users_path %>
+            <%= link_to t(".users"), fasp_base.admin_users_path %>
             <% if registration_invite_only? %>
-              <%= nav_link_to t(".invitation_codes"), fasp_base.admin_invitation_codes_path %>
+              <%= link_to t(".invitation_codes"), fasp_base.admin_invitation_codes_path %>
             <% end %>
-            <%= nav_link_to t(".follow_recommendation_presets"), main_app.admin_follow_recommendation_presets_path %>
-            <%= nav_link_to t(".mission_control"), '/jobs' %>
-            <%= nav_link_to t(".settings"), fasp_base.admin_settings_path %>
+            <%= link_to t(".follow_recommendation_presets"), main_app.admin_follow_recommendation_presets_path %>
+            <%= link_to t(".mission_control"), '/jobs' %>
+            <%= link_to t(".settings"), fasp_base.admin_settings_path %>
           <% end %>
-        </div>
-        <div class="flex gap-8">
+        </section>
+        <section>
           <% if admin_signed_in? %>
             <%= nav_link_to t(".sign_out"), fasp_base.admin_session_path, data: {turbo_method: :delete} %>
           <% end %>
-        </div>
+        </section>
       </nav>
     </header>
     <main class="container mx-auto mt-8 px-5">
-      <%= notification(notice) if notice %>
-      <%= notification(alert, type: :alert) if alert %>
+      <%= render_notification(notice) if notice %>
+      <%= render_notification(alert, type: :alert) if alert %>
 
       <%= yield %>
     </main>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -43,7 +43,7 @@
         </section>
       </nav>
     </header>
-    <main class="container mx-auto mt-8 px-5">
+    <main class="container">
       <%= render_notification(notice) if notice %>
       <%= render_notification(alert, type: :alert) if alert %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
         </section>
       </nav>
     </header>
-    <main class="container mx-auto mt-8 px-5">
+    <main class="container">
       <%= render_notification(notice) if notice %>
       <%= render_notification(alert, type: :alert) if alert %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,38 +13,35 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <header class="bg-blue-100">
-      <nav class="container mx-auto p-4 flex justify-between">
-        <div class="flex gap-8">
-          <p class="font-bold text-gray-600 px-2 py-1">
-            <%= link_to Rails.application.name, main_app.root_path %>
-          </p>
+    <header>
+      <nav class="container">
+        <section>
+          <%= link_to Rails.application.name, main_app.root_path %>
           <% if signed_in? %>
-            <%= nav_link_to t(".trends"), main_app.content_trends_path %>
-            <%= nav_link_to t(".account_search"), main_app.account_search_path %>
+            <%= link_to t(".trends"), main_app.content_trends_path %>
+            <%= link_to t(".account_search"), main_app.account_search_path %>
           <% end %>
-        </div>
-        <div class="flex gap-8">
+        </section>
+        <section>
           <% if signed_in? %>
-            <%= nav_link_to t('.sign_out'), fasp_base.session_path, data: {turbo_method: :delete} %>
+            <%= link_to t('.sign_out'), fasp_base.session_path, data: {turbo_method: :delete} %>
           <% else %>
             <% if registration_enabled? %>
-              <%= nav_link_to t(".sign_up"), fasp_base.new_registration_path %>
+              <%= link_to t(".sign_up"), fasp_base.new_registration_path %>
             <% end %>
-            <%= nav_link_to t(".sign_in"), fasp_base.new_session_path %>
+            <%= link_to t(".sign_in"), fasp_base.new_session_path %>
           <% end %>
-        </div>
+        </section>
       </nav>
     </header>
     <main class="container mx-auto mt-8 px-5">
-      <%= notification(notice) if notice %>
-      <%= notification(alert, type: :alert) if alert %>
+      <%= render_notification(notice) if notice %>
+      <%= render_notification(alert, type: :alert) if alert %>
 
       <%= yield %>
     </main>

--- a/app/views/link_trends/index.html.erb
+++ b/app/views/link_trends/index.html.erb
@@ -1,9 +1,6 @@
 <%= render_tabs ApplicationHelper::TRENDS_TABS, active: :links, scope: "trends.tabs" %>
 
-<%= page_header do %>
-  <%= t(".link_trends") %>
-<% end %>
-
+<h1><%= t(".link_trends") %></h1>
 
 <table>
   <thead>
@@ -16,11 +13,11 @@
   <tbody>
     <% @trending_links.each do |link| %>
       <tr>
-        <%= td do %>
+        <td>
           <%= link_to truncate(link.url, length: 100), link.url %>
-        <% end %>
-        <%= td do %><%= link.score %><% end %>
-        <%= td do %><%= link.rank %><% end %>
+        </td>
+        <td><%= link.score %></td>
+        <td><%= link.rank %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
Tailwind helped me out initially to get something out quickly, but it has become a maintenance burden. This is an attempt to replace it with some minimal(-ish) static CSS.

Instead of trying to rebuild what was there 1:1 I took the liberty to change the visual style a bit, so it actually looks a tiny bit different.

And while I was at it, I also added a dark mode, which was surprisingly easy to do.

All in all it is nothing worth calling a "design", but it is so far rather lightweight while still being extensible and allows us to drop a problematic dependency. 

Fixes WEB-1095