### PR TITLE
Upgrade httpx and add concurrency controls to jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,9 +46,6 @@ gem "prometheus_exporter", require: false
 gem "fasp_base", github: "mastodon/fasp_ruby", glob: "fasp_base/*.gemspec"
 gem "fasp_data_sharing", github: "mastodon/fasp_ruby", glob: "fasp_data_sharing/*.gemspec"
 
-# Lock httpx to last known-good version, timeouts in 1.8.0 seem to not work
-gem "httpx", "1.7.8"
-
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,8 +144,8 @@ GEM
     hashdiff (1.2.1)
     htmlentities (4.4.2)
     http-2 (1.2.1)
-    httpx (1.7.8)
-      http-2 (>= 1.1.3)
+    httpx (1.8.0)
+      http-2 (>= 1.2.0)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -411,7 +411,6 @@ DEPENDENCIES
   fasp_base!
   fasp_data_sharing!
   htmlentities
-  httpx (= 1.7.8)
   importmap-rails
   jbuilder
   loofah

--- a/app/jobs/retrieve_actor_job.rb
+++ b/app/jobs/retrieve_actor_job.rb
@@ -7,6 +7,9 @@ class RetrieveActorJob < ApplicationJob
   # overwhelm servers.
   # limits_concurrency to: 300, key: ->(uri) { URI(uri).host }, duration: 5.minutes, group: "retrieval"
 
+  # Only allow a single job per URI at the same time
+  limits_concurrency key: ->(uri, _) { uri }, on_conflict: :discard
+
   def perform(uri, update = false)
     return if !update && Actor.where(uri:).exists?
 

--- a/app/jobs/retrieve_content_job.rb
+++ b/app/jobs/retrieve_content_job.rb
@@ -7,6 +7,9 @@ class RetrieveContentJob < ApplicationJob
   # overwhelm servers.
   # limits_concurrency to: 300, key: ->(uri) { URI(uri).host }, duration: 5.minutes, group: "retrieval"
 
+  # Only allow a single job per URI at the same time
+  limits_concurrency key: ->(uri, _) { uri }, on_conflict: :discard
+
   def perform(uri, update = false)
     return if !update && ContentObject.where(uri:).exists?
 


### PR DESCRIPTION
The problems that seemed to have been solved by the downgrade re-appeared overnight, so it probably was not the culprit after all. This reverts the downgrade.

Additionally this includes some experimental concurrency controls for jobs in the hopes of having less duplicate jobs.