### PR TITLE
Update httpx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,8 +64,6 @@ USER 1000:1000
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
-ADD --unpack=true https://github.com/rbspy/rbspy/releases/download/v0.49.0/rbspy-x86_64-unknown-linux-musl.tar.gz ./tmp/
-
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
 CMD ["./bin/rails", "server"]

--- a/Gemfile
+++ b/Gemfile
@@ -60,9 +60,6 @@ group :opentelemetry do
   gem "opentelemetry-sdk", "~> 1.12", require: false
 end
 
-# Use master branch to help debug a problem in release version
-gem "httpx", git: "https://gitlab.com/os85/httpx.git", branch: "issue-388"
-
 # Get stacktrace of running process
 gem "sigdump", require: "sigdump/setup"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,14 +19,6 @@ GIT
       fasp_base
       rails (>= 8.0.0)
 
-GIT
-  remote: https://gitlab.com/os85/httpx.git
-  revision: fbd6e6c0e8944ec7f6195c6f7daa41c37664035b
-  branch: issue-388
-  specs:
-    httpx (1.8.0)
-      http-2 (>= 1.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -175,6 +167,8 @@ GEM
     hashdiff (1.2.1)
     htmlentities (4.4.2)
     http-2 (1.2.1)
+    httpx (1.8.1)
+      http-2 (>= 1.2.0)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -502,7 +496,6 @@ DEPENDENCIES
   fasp_base!
   fasp_data_sharing!
   htmlentities
-  httpx!
   importmap-rails
   jbuilder
   loofah


### PR DESCRIPTION
Fixes have been released, so no longer depend on git branch.

Also remove rbspy from Dockerfile.