### PR TITLE
Overhaul trend rank calculation

### DIFF
--- a/app/controllers/content_trends_controller.rb
+++ b/app/controllers/content_trends_controller.rb
@@ -1,5 +1,5 @@
 class ContentTrendsController < ApplicationController
   def index
-    @trending_content = ContentObject.trending(limit: 100)
+    @trending_content = ContentObject.ranked_trending(limit: 100)
   end
 end

--- a/app/controllers/fasp/trends/v0/contents_controller.rb
+++ b/app/controllers/fasp/trends/v0/contents_controller.rb
@@ -1,6 +1,6 @@
 class Fasp::Trends::V0::ContentsController < Fasp::ApiController
   def index
-    trending_content = ContentObject.trending(**trend_params)
+    trending_content = ContentObject.ranked_trending(**trend_params)
 
     render json: { content: trending_content.map { |c| { uri: c.uri, rank: c.rank } } }
   end

--- a/app/controllers/fasp/trends/v0/hashtags_controller.rb
+++ b/app/controllers/fasp/trends/v0/hashtags_controller.rb
@@ -1,7 +1,6 @@
 class Fasp::Trends::V0::HashtagsController < Fasp::ApiController
   def index
-    trending_hashtags = Hashtag.includes(:recent_examples)
-      .trending(**trend_params)
+    trending_hashtags = Hashtag.ranked_trending(**trend_params)
 
     render json: { hashtags: trending_hashtags.map { |c| { name: c.name, rank: c.rank, examples: c.recent_examples.map(&:uri) } } }
   end

--- a/app/controllers/fasp/trends/v0/links_controller.rb
+++ b/app/controllers/fasp/trends/v0/links_controller.rb
@@ -1,7 +1,6 @@
 class Fasp::Trends::V0::LinksController < Fasp::ApiController
   def index
-    trending_links = Link.includes(:recent_examples)
-      .trending(**trend_params)
+    trending_links = Link.ranked_trending(**trend_params)
 
     render json: { links: trending_links.map { |l| { url: l.url, rank: l.rank, examples: l.recent_examples.map(&:uri) } } }
   end

--- a/app/controllers/hashtag_trends_controller.rb
+++ b/app/controllers/hashtag_trends_controller.rb
@@ -1,5 +1,5 @@
 class HashtagTrendsController < ApplicationController
   def index
-    @trending_hashtags = Hashtag.trending(limit: 100)
+    @trending_hashtags = Hashtag.ranked_trending(limit: 100)
   end
 end

--- a/app/controllers/link_trends_controller.rb
+++ b/app/controllers/link_trends_controller.rb
@@ -1,5 +1,5 @@
 class LinkTrendsController < ApplicationController
   def index
-    @trending_links = Link.trending(limit: 100)
+    @trending_links = Link.ranked_trending(limit: 100)
   end
 end

--- a/app/models/concerns/rankable_concern.rb
+++ b/app/models/concerns/rankable_concern.rb
@@ -1,9 +1,23 @@
 module RankableConcern
   extend ActiveSupport::Concern
 
-  def rank
-    return 0 unless respond_to?(:score)
+  included do
+    attr_accessor :rank
+  end
 
-    (100.0 / (1.0 + Math::E ** (-0.03 * (score - 100)))).floor
+  class_methods do
+    # Rank score of a list of records. Assumes the first record
+    # in the list has the highest score, which is the case for
+    # calculated trends
+    def rank(list)
+      return if list.blank?
+
+      max_score = list.first.score
+      one_percent = max_score / 100.0
+
+      list.each do |item|
+        item.rank = (item.score / one_percent).ceil.to_i
+      end
+    end
   end
 end

--- a/app/models/content_object.rb
+++ b/app/models/content_object.rb
@@ -32,6 +32,10 @@ class ContentObject < ApplicationRecord
   scope :trending, TrendsQuery
 
   class << self
+    def ranked_trending(...)
+      rank(trending(...))
+    end
+
     def json_to_attributes(json_object)
       hashtags = (json_object["tag"] || []).filter_map { |t| t["name"] if t["type"] == "Hashtag" }
       links = LinkExtractor.new(json_object).extracted_urls

--- a/app/models/hashtag.rb
+++ b/app/models/hashtag.rb
@@ -10,4 +10,8 @@ class Hashtag < ApplicationRecord
     through: :hashtag_usages, source: :content_object
 
   scope :trending, TrendsQuery
+
+  def self.ranked_trending(...)
+    rank(includes(:recent_examples).trending(...))
+  end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -10,4 +10,8 @@ class Link < ApplicationRecord
     through: :link_usages, source: :content_object
 
   scope :trending, TrendsQuery
+
+  def self.ranked_trending(...)
+    rank(includes(:recent_examples).trending(...))
+  end
 end

--- a/test/models/concerns/rankable_concern_test.rb
+++ b/test/models/concerns/rankable_concern_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class RankableConcernTest < ActiveSupport::TestCase
+  class Record
+    include RankableConcern
+
+    attr_reader :score
+
+    def initialize(score) = @score = score
+  end
+
+  test "::rank returns a rank between 0 and 100" do
+    records = [ 10, 7, 4, 1 ].map { |i| Record.new(i) }
+    Record.rank(records)
+
+    assert_equal [ 100, 70, 40, 10 ], records.map(&:rank)
+
+    records = [ 1000, 768, 102, 1 ].map { |i| Record.new(i) }
+    Record.rank(records)
+
+    assert_equal [ 100, 77, 11, 1 ], records.map(&:rank)
+  end
+end


### PR DESCRIPTION
The old one did not adjust well to small real world data (e.g. hashtag trends for the last hour only) as too many small values were mapped to the same rank.

This new approach always assigns the maximum rank number (100) to the top result and maps other values accordingly.