### PR TITLE
Add bundler setup again

### DIFF
--- a/bin/prometheus_exporter
+++ b/bin/prometheus_exporter
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require "rubygems"
+require "bundler/setup"
 
 ARGV.unshift("-a", "lib/prometheus_exporter/server/solid_queue_collector.rb")
 


### PR DESCRIPTION
Reverts last change after which `prometheus_exporter` could not be started.