### PR TITLE
fix PG::ForeignKeyViolation: ERROR

### DIFF
--- a/app/models/content_activity.rb
+++ b/app/models/content_activity.rb
@@ -21,6 +21,10 @@ class ContentActivity < ApplicationRecord
   rescue ActiveRecord::RecordNotFound
     # It is possible that the activity has been deleted between
     # ::find_or_create_by and #with_lock
+  rescue ActiveRecord::InvalidForeignKey
+    # the content object has been deleted between create_from_json! and record
+    # insert or update on table "content_activities" violates foreign key constraint
+    # Key is not present in table "content_objects"
   end
 
   def self.record_reply(content_object, replied_at)

--- a/test/models/content_activity_test.rb
+++ b/test/models/content_activity_test.rb
@@ -15,4 +15,11 @@ class ContentActivityTest < ActiveSupport::TestCase
 
     assert_equal content_objects.last.content_activities.order(hour_of_activity: :asc).last.score, distribution[content_objects.last.id].last
   end
+
+  test "::record when content object is deleted" do
+    content = content_objects(:complex_language_tag)
+    ContentObject.find_by(id: content.id).destroy
+
+    assert_nil ContentActivity.record(content)
+  end
 end


### PR DESCRIPTION
a content object can be deleted, before the content action is recorded
adds a testcase and a rescue, to catch the error

https://discovery.joinmastodon.org/jobs/applications/fediscoverer/jobs/383fc979-3265-450f-b64a-2f16972b6b0f?server_id=solid_queue#error

implements WEB-1191