### PR TITLE
fix ActiveRecord::RecordNotFound: [WHERE "content_objects"."uri" = $1]

### DIFF
--- a/app/models/content_object.rb
+++ b/app/models/content_object.rb
@@ -79,6 +79,9 @@ class ContentObject < ApplicationRecord
       attributes = json_to_attributes(json_object).merge(actor:)
 
       create_with(attributes).find_or_create_by!(uri: json_object["id"])
+
+    rescue ActiveRecord::RecordNotFound
+      # It is possible that RetrieveActorJob is not yet complete and actor can't be found
     end
 
     private


### PR DESCRIPTION
https://discovery.joinmastodon.org/jobs/applications/fediscoverer/jobs/222622af-54a2-409a-92c3-ade606aa1367?server_id=solid_queue

ActiveRecord::RecordNotFound: Couldn't find ContentObject with [WHERE "content_objects"."uri" = $1] 

in `ContentObject::create_from_json!` it is possible, that the `RetrieveActorJob` is not returning an actor.


```
/usr/local/bundle/ruby/4.0.0/gems/activerecord-8.1.3.1/lib/active_record/relation/finder_methods.rb:425:in 'ActiveRecord::FinderMethods#raise_record_not_found_exception!'
/usr/local/bundle/ruby/4.0.0/gems/activerecord-8.1.3.1/lib/active_record/relation/finder_methods.rb:135:in 'ActiveRecord::FinderMethods#take!'
/usr/local/bundle/ruby/4.0.0/gems/activerecord-8.1.3.1/lib/active_record/relation/finder_methods.rb:118:in 'ActiveRecord::FinderMethods#find_by!'
/usr/local/bundle/ruby/4.0.0/gems/activerecord-8.1.3.1/lib/active_record/relation.rb:305:in 'block in ActiveRecord::Relation#create_or_find_by!'
/usr/local/bundle/ruby/4.0.0/gems/activerecord-8.1.3.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:463:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
/usr/local/bundle/ruby/4.0.0/gems/activerecord-8.1.3.1/lib/active_record/connection_handling.rb:313:in 'ActiveRecord::ConnectionHandling#with_connection'
/usr/local/bundle/ruby/4.0.0/gems/activerecord-8.1.3.1/lib/active_record/relation/delegation.rb:105:in 'ActiveRecord::Delegation#with_connection'
/usr/local/bundle/ruby/4.0.0/gems/activerecord-8.1.3.1/lib/active_record/relation.rb:294:in 'ActiveRecord::Relation#create_or_find_by!'
/usr/local/bundle/ruby/4.0.0/gems/activerecord-8.1.3.1/lib/active_record/relation.rb:239:in 'ActiveRecord::Relation#find_or_create_by!'
/rails/app/models/content_object.rb:81:in 'ContentObject.create_from_json!'
/rails/app/jobs/retrieve_content_job.rb:30:in 'RetrieveContentJob#perform'
```

implements WEB-1205