### PR TITLE
error foreign key not present in content objects table

### DIFF
--- a/app/jobs/fasp_data_sharing/process_content_update_job.rb
+++ b/app/jobs/fasp_data_sharing/process_content_update_job.rb
@@ -4,7 +4,7 @@ module FaspDataSharing
     queue_as :ingress
 
     def perform(uri)
-      return if ContentObject.where(uri:).blank?
+      return if ContentObject.where(uri:).none?
 
       ::UpdateContentJob.perform_later(uri)
     end

--- a/app/jobs/fasp_data_sharing/process_content_update_job.rb
+++ b/app/jobs/fasp_data_sharing/process_content_update_job.rb
@@ -4,6 +4,8 @@ module FaspDataSharing
     queue_as :ingress
 
     def perform(uri)
+      return if ContentObject.where(uri:).blank?
+
       ::RetrieveContentJob.perform_later(uri, true)
     end
   end

--- a/app/jobs/fasp_data_sharing/process_content_update_job.rb
+++ b/app/jobs/fasp_data_sharing/process_content_update_job.rb
@@ -6,7 +6,7 @@ module FaspDataSharing
     def perform(uri)
       return if ContentObject.where(uri:).blank?
 
-      ::RetrieveContentJob.perform_later(uri, true)
+      ::UpdateContentJob.perform_later(uri)
     end
   end
 end

--- a/app/jobs/retrieve_content_job.rb
+++ b/app/jobs/retrieve_content_job.rb
@@ -12,6 +12,7 @@ class RetrieveContentJob < ApplicationJob
 
   def perform(uri, update = false)
     return if !update && ContentObject.where(uri:).exists?
+    return if update && ContentObject.where(uri:).blank?
 
     server = Server.from_uri(uri)
     return if server.blocked?

--- a/app/jobs/retrieve_content_job.rb
+++ b/app/jobs/retrieve_content_job.rb
@@ -8,16 +8,16 @@ class RetrieveContentJob < ApplicationJob
   # limits_concurrency to: 300, key: ->(uri) { URI(uri).host }, duration: 5.minutes, group: "retrieval"
 
   # Only allow a single job per URI at the same time
-  limits_concurrency key: ->(uri, _ = false) { uri }, on_conflict: :discard
+  limits_concurrency key: ->(uri) { uri }, on_conflict: :discard
 
-  def perform(uri, update = false)
-    return if !update && ContentObject.where(uri:).exists?
-    return if update && ContentObject.where(uri:).blank?
+  def perform(uri)
+    return if ContentObject.where(uri:).exists?
 
     server = Server.from_uri(uri)
     return if server.blocked?
 
     content_json = server.fetch(uri)
+    return if content_json.blank?
 
     # Handle reblogs
     if content_json.dig("type") == "Announce"
@@ -25,11 +25,7 @@ class RetrieveContentJob < ApplicationJob
       uri = content_json["id"]
     end
 
-    if ContentObject.where(uri:).exists? && update
-      ContentObject.where(uri:).take.update_from_json(content_json)
-    elsif !update
-      ContentObject.create_from_json!(content_json)
-    end
+    ContentObject.create_from_json!(content_json)
   rescue HTTPX::HTTPError => e
     raise if e.status >= 500
   end

--- a/app/jobs/retrieve_content_job.rb
+++ b/app/jobs/retrieve_content_job.rb
@@ -27,7 +27,7 @@ class RetrieveContentJob < ApplicationJob
 
     if ContentObject.where(uri:).exists? && update
       ContentObject.where(uri:).take.update_from_json(content_json)
-    else
+    elsif !update
       ContentObject.create_from_json!(content_json)
     end
   rescue HTTPX::HTTPError => e

--- a/app/jobs/update_content_job.rb
+++ b/app/jobs/update_content_job.rb
@@ -1,0 +1,32 @@
+class UpdateContentJob < ApplicationJob
+  queue_as :retrieval
+
+  # Idea to stay within Mastodon's default rate-limits. These do not apply
+  # if server is behind a caching proxy which most servers should be.
+  # It still might be nice to define _some_ limit here as to not
+  # overwhelm servers.
+  # limits_concurrency to: 300, key: ->(uri) { URI(uri).host }, duration: 5.minutes, group: "retrieval"
+
+  # Only allow a single job per URI at the same time
+  limits_concurrency key: ->(uri) { uri }, on_conflict: :discard
+
+  def perform(uri)
+    content = ContentObject.where(uri:)
+    return if content.blank?
+
+    server = Server.from_uri(uri)
+    return if server.blocked?
+
+    content_json = server.fetch(uri)
+
+    # Handle reblogs
+    if content_json.dig("type") == "Announce"
+      content_json = content_json["object"]
+      uri = content_json["id"]
+    end
+
+    content.take.update_from_json(content_json)
+  rescue HTTPX::HTTPError => e
+    raise if e.status >= 500
+  end
+end

--- a/app/jobs/update_content_job.rb
+++ b/app/jobs/update_content_job.rb
@@ -18,6 +18,7 @@ class UpdateContentJob < ApplicationJob
     return if server.blocked?
 
     content_json = server.fetch(uri)
+    return if content_json.blank?
 
     # Handle reblogs
     if content_json.dig("type") == "Announce"

--- a/app/jobs/update_content_job.rb
+++ b/app/jobs/update_content_job.rb
@@ -11,7 +11,7 @@ class UpdateContentJob < ApplicationJob
   limits_concurrency key: ->(uri) { uri }, on_conflict: :discard
 
   def perform(uri)
-    content = ContentObject.where(uri:)
+    content = ContentObject.find_by(uri:)
     return if content.blank?
 
     server = Server.from_uri(uri)
@@ -26,7 +26,7 @@ class UpdateContentJob < ApplicationJob
       uri = content_json["id"]
     end
 
-    content.take.update_from_json(content_json)
+    content.update_from_json(content_json)
   rescue HTTPX::HTTPError => e
     raise if e.status >= 500
   end

--- a/test/jobs/fasp_data_sharing/process_content_update_job_test.rb
+++ b/test/jobs/fasp_data_sharing/process_content_update_job_test.rb
@@ -4,7 +4,6 @@ module FaspDataSharing
   class ProcessContentUpdateJobTest < ActiveJob::TestCase
     setup do
       @uri = "https://mastodon.example.com/status/4711"
-      mock_valid_content_request(uri: @uri)
       @job = ProcessContentUpdateJob.new
       @actor_uri = "https://unknown.example.com/users/NewActor"
     end
@@ -18,25 +17,13 @@ module FaspDataSharing
       assert(job.perform_now)
     end
 
-    test "does not enqueue job when content object is deleted before enqueing update" do
-      mock_valid_actor_request(uri: @actor_uri)
-      mock_valid_content_request(uri: @uri, actor: @actor_uri)
-      RetrieveContentJob.new.perform(@uri)
-      ContentObject.where(uri: @uri).first.destroy
-
+    test "does not enqueue job when content object is not existent" do
       assert_enqueued_jobs(0) do
         @job.perform(@uri)
       end
-    end
-
-    test "does not create a new object, and returns from job when content object cannot be found on update" do
-      mock_valid_actor_request(uri: @actor_uri)
-      mock_valid_content_request(uri: @uri, actor: @actor_uri)
-      RetrieveContentJob.new.perform(@uri)
       queue = @job.perform(@uri)
-      ContentObject.where(uri: @uri).first.destroy
 
-      assert_nil queue.perform_now
+      assert_nil queue
       assert ContentObject.where(uri: @uri).blank?
     end
   end

--- a/test/jobs/fasp_data_sharing/process_content_update_job_test.rb
+++ b/test/jobs/fasp_data_sharing/process_content_update_job_test.rb
@@ -9,6 +9,15 @@ module FaspDataSharing
       @actor_uri = "https://unknown.example.com/users/NewActor"
     end
 
+    test "updates successfully when content object is present" do
+      mock_valid_actor_request(uri: @actor_uri)
+      mock_valid_content_request(uri: @uri, actor: @actor_uri)
+      RetrieveContentJob.new.perform(@uri)
+
+      job = @job.perform(@uri)
+      assert(job.perform_now)
+    end
+
     test "does not enqueue job when content object is deleted before enqueing update" do
       mock_valid_actor_request(uri: @actor_uri)
       mock_valid_content_request(uri: @uri, actor: @actor_uri)

--- a/test/jobs/fasp_data_sharing/process_content_update_job_test.rb
+++ b/test/jobs/fasp_data_sharing/process_content_update_job_test.rb
@@ -2,8 +2,33 @@ require "test_helper"
 
 module FaspDataSharing
   class ProcessContentUpdateJobTest < ActiveJob::TestCase
-    # test "the truth" do
-    #   assert true
-    # end
+    setup do
+      @uri = "https://mastodon.example.com/status/4711"
+      mock_valid_content_request(uri: @uri)
+      @job = ProcessContentUpdateJob.new
+      @actor_uri = "https://unknown.example.com/users/NewActor"
+    end
+
+    test "does not enqueue job when content object is deleted before enqueing update" do
+      mock_valid_actor_request(uri: @actor_uri)
+      mock_valid_content_request(uri: @uri, actor: @actor_uri)
+      RetrieveContentJob.new.perform(@uri)
+      ContentObject.where(uri: @uri).first.destroy
+
+      assert_enqueued_jobs(0) do
+        @job.perform(@uri)
+      end
+    end
+
+    test "does not create a new object, and returns from job when content object cannot be found on update" do
+      mock_valid_actor_request(uri: @actor_uri)
+      mock_valid_content_request(uri: @uri, actor: @actor_uri)
+      RetrieveContentJob.new.perform(@uri)
+      queue = @job.perform(@uri)
+      ContentObject.where(uri: @uri).first.destroy
+
+      assert_nil queue.perform_now
+      assert ContentObject.where(uri: @uri).blank?
+    end
   end
 end

--- a/test/jobs/fasp_data_sharing/process_content_update_job_test.rb
+++ b/test/jobs/fasp_data_sharing/process_content_update_job_test.rb
@@ -5,16 +5,15 @@ module FaspDataSharing
     setup do
       @uri = "https://mastodon.example.com/status/4711"
       @job = ProcessContentUpdateJob.new
-      @actor_uri = "https://unknown.example.com/users/NewActor"
     end
 
     test "updates successfully when content object is present" do
-      mock_valid_actor_request(uri: @actor_uri)
-      mock_valid_content_request(uri: @uri, actor: @actor_uri)
+      mock_valid_content_request(uri: @uri)
       RetrieveContentJob.new.perform(@uri)
 
-      job = @job.perform(@uri)
-      assert(job.perform_now)
+      assert_enqueued_with(job: ::UpdateContentJob, args: [ @uri ]) do
+        @job.perform(@uri)
+      end
     end
 
     test "does not enqueue job when content object is not existent" do


### PR DESCRIPTION
https://discovery.joinmastodon.org/jobs/applications/fediscoverer/jobs/0fdef580-d6ea-41b4-8b95-d8ef27c3ed6e?server_id=solid_queue#error

as I understand this error, it seems to be possible, that we try to update a content object, which is not there anymore.
I wrote some specs to emulate this situation (how ever it may be produced in a real live scenario) it seems that without the early returns, we would enter the part of the the if loop, that is responsible for saving new records.

another measure is to make the if else cases explicit and not to catch all by creating a new object.
It might be even an idea, to completely separate the update cases from the create cases, to avoid recreating a deleted object

implements WEB-1255