### PR TITLE
fix invalid URI error strip trailing space from href

### DIFF
--- a/app/models/content_object/link_extractor.rb
+++ b/app/models/content_object/link_extractor.rb
@@ -11,7 +11,7 @@ class ContentObject::LinkExtractor
 
   def extract_urls
     parsed_fragment.css("a[href]:not([rel~=tag]):not(.u-url)").filter_map do |a|
-      a["href"] unless mention?(a["href"])
+      a["href"].strip unless mention?(a["href"])
     end
   end
 

--- a/test/models/content_object/link_extractor_test.rb
+++ b/test/models/content_object/link_extractor_test.rb
@@ -11,6 +11,25 @@ class ContentObject::LinkExtractorTest < ActiveSupport::TestCase
     assert_equal "https://example.com/home", extracted_urls.first
   end
 
+  test "#extracted_urls can handle trailing space" do
+    content_json = <<~HTML
+      <p>Test</p><p><a href="https://fedi.example.com/tags/testtag " class="mention hashtag" rel="tag">#<span>testtag</span></a> test <span class="h-card" translate="no"><a href="https://fedi.example.com/@user1 " class="u-url mention">@<span>user1</span></a></span><a href="https://example.com/home " target="_blank" rel="nofollow noopener" translate="no"><span class="invisible">https://</span><span class="">example.com/home</span><span class="invisible"></span></a> test <a href="https://fedi.example.com/@user2 ">@user2</a>
+    HTML
+
+    mention_hash = {
+      "type" => "Mention",
+      "href" => "https://fedi.example.com/@user2 ",
+      "name" => "@user2@fedi.example.com"
+    }
+
+    content_object = mock_content_object(content: content_json)
+    content_object["tag"] << mention_hash
+    extracted_urls = ContentObject::LinkExtractor.new(content_object).extracted_urls
+
+    assert_equal 1, extracted_urls.size
+    assert_equal "https://example.com/home", extracted_urls.first
+  end
+
   private
 
   def content


### PR DESCRIPTION
the content body had a trailing space in a link that was passed from the link extractor to the uri_normalizer causing an error there.
https://discovery.joinmastodon.org/jobs/applications/fediscoverer/jobs/b2a8adc7-3502-4cfd-b5f2-acb4eab08331?server_id=solid_queue#error

fixes WEB-1258